### PR TITLE
Fix command not found message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tiagonapoli/oclif-plugin-spaced-commands",
   "description": "convert an oclif CLI to use spaced commands",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "Philipe Navarro @RasPhilCo, Tiago Nápoli @tiagonapoli",
   "bugs": "https://github.com/tiagonapoli/oclif-plugin-spaced-commands",
   "homepage": "https://github.com/tiagonapoli/oclif-plugin-spaced-commands",

--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -84,6 +84,7 @@ export const init: Config.Hook<'init'> = async function (ctx) {
 
   // overwrite config.runCommand
   ctx.config.runCommand = async (cmdId: string, argv: string[] = []) => {
+    const originalId = cmdId
     // tslint:disable-next-line:no-unused
     const [_, name] = tree.findMostProgressiveCmd(RAWARGV)
     // override the id b/c of the closure
@@ -93,7 +94,7 @@ export const init: Config.Hook<'init'> = async function (ctx) {
     const c = ctx.config.findCommand('')
     if (!c) {
       await ctx.config.runHook('command_not_found', { id: cmdId })
-      throw new CLIError(`command ${cmdId} not found`)
+      throw new CLIError(`command ${originalId} not found`)
     }
     const command = c.load()
     await ctx.config.runHook('prerun', { Command: command, argv })


### PR DESCRIPTION
Before the command not found message was like `Error: command  not found` instead of `Error: command command_name not found`.