### PR TITLE
Fix aliases documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tiagonapoli/oclif-plugin-spaced-commands",
   "description": "convert an oclif CLI to use spaced commands",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "Philipe Navarro @RasPhilCo, Tiago Nápoli @tiagonapoli",
   "bugs": "https://github.com/tiagonapoli/oclif-plugin-spaced-commands",
   "homepage": "https://github.com/tiagonapoli/oclif-plugin-spaced-commands",


### PR DESCRIPTION
In the documentation from `--help` the aliases from subcommands are being showed with `:` instead of ` `. This PR fixes it.