### PR TITLE
fix: Correct a typescript linting error

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@oclif/command": "^1.0.0",
     "@oclif/config": "^1.0.0",
     "@oclif/errors": "^1.2.2",
+    "@types/treeify": "^1.0.0",
     "chalk": "^2.4.1",
     "indent-string": "^3.2.0",
     "strip-ansi": "^5.0.0",

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -38,7 +38,7 @@ class Tree {
     }
 
     const tree = addNodes(this.nodes)
-    logger(treeify.asTree(tree))
+    logger(treeify.asTree(tree, true, true))
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,6 +193,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.19.tgz#1d31ddd5503dba2af7a901aafef3392e4955620e"
   integrity sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ==
 
+"@types/treeify@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/treeify/-/treeify-1.0.0.tgz#f04743cb91fc38254e8585d692bd92503782011c"
+  integrity sha512-ONpcZAEYlbPx4EtJwfTyCDQJGUpKf4sEcuySdCVjK5Fj/3vHp5HII1fqa1/+qrsLnpYELCQTfVW/awsGJePoIg==
+
 "@typescript-eslint/eslint-plugin@^2.17.0":
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.28.0.tgz#4431bc6d3af41903e5255770703d4e55a0ccbdec"


### PR DESCRIPTION
Looks like in the method definition for `asTree` the last 2 arguments aren't optional:
```
export function asTree(
    treeObj: TreeObject,
    showValues: boolean,
    hideFunctions: boolean
): string;
```