### PR TITLE
Use replace instead of replaceAll for compatibility

### DIFF
--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -62,7 +62,7 @@ export const init: Config.Hook<'init'> = async function (ctx) {
   // @ts-ignore
   CommandHelp.prototype.defaultUsage = function (_: Config.Command.Flag[]): string {
     return compact([
-      this.command.id.replaceAll(':', ' '),
+      this.command.id.replace(/:/g, ' '),
       this.command.args
         .filter((a: any) => !a.hidden)
         .map((a: any) => this.arg(a))


### PR DESCRIPTION
During tests I noticed the plugin wasn't working with my current Node.js version
```
TypeError: this.command.id.replaceAll is not a function
    at CommandHelp.command_1.default.defaultUsage (/tmp/toolbelt/node_modules/@tiagonapoli/oclif-plugin-spaced-commands/lib/hooks/init.js:58:29)
    at CommandHelp.usage (/tmp/toolbelt/node_modules/@oclif/plugin-help/lib/command.js:44:63)
    at CommandHelp.command_1.default.generate (/tmp/toolbelt/node_modules/@tiagonapoli/oclif-plugin-spaced-commands/lib/hooks/init.js:187:18
```
`replaceAll` was introduced on nodejs v15.0.0. We can use `replace` with regex instead and support more nodejs versions 